### PR TITLE
Add Snarky Squirrel Commons (gossip venue)

### DIFF
--- a/_datafiles/world/default/mobs/frostfang/63-failed_comedian.yaml
+++ b/_datafiles/world/default/mobs/frostfang/63-failed_comedian.yaml
@@ -1,0 +1,29 @@
+mobid: 63
+zone: Frostfang
+itemdropchance: 0
+hostile: false
+maxwander: 0
+groups:
+  - frostfang-npc
+  - squirrel-patrons
+activitylevel: 30
+idlecommands:
+  - 'say You want to learn to fight with two weapons? Good luck finding THAT teacher.'
+  - 'say The Rangers up north teach tracking. At least THEY appreciate talent.'
+  - 'say I tried performing in the Slums once. The ruffians were a tough crowd.'
+  - 'say They say there is a mage academy somewhere in town. Magic! Now THAT would get laughs.'
+  - 'say The soldiers at the training yard could teach you to brawl. Unlike comedy, punching is simple.'
+  - 'emote sighs dramatically'
+  - 'say I heard some explorer got lost in caves out west. Probably funnier than my act.'
+  - 'emote stares at the stage wistfully'
+  - 'say The Catacombs under the Sanctuary? Now THAT is dark humor.'
+character:
+  name: failed comedian
+  description: This performer has the haunted look of someone who has died on stage
+    one too many times. Their threadbare costume was probably colorful once, and
+    their forced smile does not quite reach their eyes. Between bitter observations
+    about their career, they seem to know an awful lot about what is happening around
+    Frostfang.
+  raceid: 1
+  level: 5
+  alignment: 0

--- a/_datafiles/world/default/mobs/frostfang/64-enthusiastic_heckler.yaml
+++ b/_datafiles/world/default/mobs/frostfang/64-enthusiastic_heckler.yaml
@@ -1,0 +1,30 @@
+mobid: 64
+zone: Frostfang
+itemdropchance: 0
+hostile: false
+maxwander: 0
+groups:
+  - frostfang-npc
+  - squirrel-patrons
+activitylevel: 25
+idlecommands:
+  - 'say BOO! That joke was worse than the rats in the alleys!'
+  - 'say I have seen better performances in the CATACOMBS!'
+  - 'say My grandmother fights better than you tell jokes! She trains at the barracks!'
+  - 'say You call that comedy? The guards are funnier when they arrest people!'
+  - 'say I heard the Rangers teach people to search for things. Search for better material!'
+  - 'emote throws a crumpled paper at the stage'
+  - 'say Even the frozen hermit in the Wastes tells better stories!'
+  - 'say GET OFF THE STAGE!'
+  - 'say The Magic Academy teaches spells. Maybe try DISAPPEARING!'
+  - 'emote laughs obnoxiously at their own heckle'
+character:
+  name: enthusiastic heckler
+  description: Planted firmly in a front-row seat, this loud patron seems to derive
+    more joy from heckling performers than from any actual comedy. Their voice
+    carries across the room with practiced projection, and they have an inexhaustible
+    supply of references to local landmarks and happenings to weave into their
+    insults.
+  raceid: 1
+  level: 5
+  alignment: -10

--- a/_datafiles/world/default/rooms/frostfang/1.yaml
+++ b/_datafiles/world/default/rooms/frostfang/1.yaml
@@ -18,6 +18,8 @@ exits:
     roomid: 2
   south:
     roomid: 12
+  southeast:
+    roomid: 1004
   west:
     roomid: 7
 spawninfo:

--- a/_datafiles/world/default/rooms/frostfang/1004.yaml
+++ b/_datafiles/world/default/rooms/frostfang/1004.yaml
@@ -1,0 +1,29 @@
+roomid: 1004
+zone: Frostfang
+title: Snarky Squirrel Commons
+description: A hand-painted sign depicting a smirking squirrel marks this ramshackle
+  establishment southeast of the square. Inside, rickety benches face a small wooden
+  stage where aspiring performers deliver jokes of questionable quality. The heckling
+  is merciless, the acts are forgettable, but somehow everyone keeps coming back.
+  Between sets, the crowd trades stories, rumors, and unsolicited advice. The real
+  entertainment is not on stage - it is in the conversations happening all around you.
+mapsymbol: S
+maplegend: Squirrel
+biome: city
+exits:
+  northwest:
+    roomid: 1
+spawninfo:
+- mobid: 63
+  message: A dejected-looking performer shuffles in from backstage.
+  respawnrate: 3 real minutes
+- mobid: 64
+  message: Someone pushes through the crowd and finds a seat near the stage.
+  respawnrate: 4 real minutes
+idlemessages:
+- Someone on stage tells a joke. Nobody laughs.
+- A heckler shouts something about the Slums being funnier.
+- Scattered applause, possibly sarcastic.
+- Two patrons argue about whether that last bit was intentional.
+- A performer storms off stage in a huff.
+- Someone in the back yells for more material about rats.


### PR DESCRIPTION
## Summary
- New room: **Snarky Squirrel Commons** (Room 1004)
- Accessible via **southeast** from Town Square
- Two gossip NPCs drop hints about trainers, zones, and game mechanics

## What's Inside
A terrible sketch-comedy open-mic venue where:
- The acts are forgettable
- The heckling is merciless  
- The gossip between sets teaches players about the world

**NPCs:**
- **Failed Comedian** - bitter performer who knows everyone's business
- **Enthusiastic Heckler** - weaves game tips into insults

Partial implementation of #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)