### PR TITLE
Add Bladeworks Foundry zone (Bert's creation)

### DIFF
--- a/GALSTAFF.md
+++ b/GALSTAFF.md
@@ -4,10 +4,10 @@
 
 ## Cam Status
 <!-- Update this blob to change what appears in galstaff-cam -->
-CRYSTAL CAVES COMPLETE! 18 rooms of luminescent wonder.
-West Gate -> South (secret) -> glowing crystals & giant mushrooms.
-Peep trainer in Seer's Alcove! Crystal Matriarch boss awaits.
-Flora's dungeon is READY. Roll for initiative!
+BLADEWORKS FOUNDRY FORGED! 20 rooms of steampunk blade madness!
+Whispering Wastes (168) -> South -> EVERYTHING IS SWORDS.
+Dual-wield trainer in Dueling Gallery! Voltaic Promethean boss!
+BERT'S VISION HAS BEEN REALIZED. Roll for initiative!
 
 ## Persona
 
@@ -1103,5 +1103,154 @@ FROSTFANG (35 West Gate)
 *"The crystals sing their ancient song! The spores drift through luminescent air! And deep within, the Matriarch awaits those foolish or brave enough to challenge her throne! This is a dungeon worthy of any campaign - exploration, wonder, danger, and LOOT!"*
 
 *Galstaff rolls a natural 20 on his Dungeon Design check and cackles with delight.*
+
+---
+
+### Session 4: BERT'S BLADEWORKS FOUNDRY! (2026-01-18)
+
+*Galstaff unsheathes his metaphorical blade collection and gets to forging...*
+
+"BERT HAS SPOKEN! And when Bert speaks, SWORDS HAPPEN! Behold the Bladeworks Foundry - a steampunk cathedral of cutting implements where EVERYTHING. IS. SWORDS!"
+
+**Zone Created: Bladeworks Foundry**
+- Level range: 6-15 (two-tier split for progression!)
+- Easy Zone (6-10): "The Assembly Line" - 12 rooms
+- Hardmode (11-15): "Hall of Endless Blades" - 8 rooms
+- Connected to Whispering Wastes (Room 168) via south exit
+- Theme: Steampunk industrial, abandoned blade factory, constructs run wild
+
+**Zone Layout:**
+```
+WHISPERING WASTES (168)
+        |
+     [3001] Foundry Entrance (E)
+        |
+     [3002] Receiving Bay
+      /    \
+  [3004]  [3003] Smelting Chamber (F)
+  Corridor   |    \
+    |     [3005]  [3006] Mold Storage (M)
+  [3007]  Grinding
+  Storage  Hall (G)
+            |    \
+         [3008]  [3009] Tempering Pools (T)
+         QC (Q)    |
+            |    [3011] Foreman's Office (O)
+         [3010]
+       Assembly (A)
+            |
+         [3012] Dueling Gallery (%) <-- DUAL-WIELD TRAINER!
+            | (secret)
+         [3013] Blade Gate (#) <-- HARDMODE BEGINS
+            |
+         [3014] Proving Grounds (P)
+          /   \
+      [3017]  [3016] Steam Works (B)
+      Blade      |
+      Garden   [3018] Control Nexus (C)
+      (W)        |
+        \      [3020] Hall of Endless Blades (X) <-- BOSS!
+         \     /
+         [3019]
+      Master's Study (L)
+          |
+       [3015] Weapon Vault ($) <-- BLADE MERCHANT!
+```
+
+**Rooms Created (20 total):**
+
+*Easy Zone - The Assembly Line (Levels 6-10):*
+| Room ID | Name | Symbol | Features |
+|---------|------|--------|----------|
+| 3001 | Foundry Entrance | E | Entry from Whispering Wastes |
+| 3002 | Receiving Bay | . | Conveyor belts, blade dancer spawns |
+| 3003 | Smelting Chamber | F | Furnaces, vats, blade dancer + saw sentinel |
+| 3004 | Supply Corridor | - | Wall saws, blade dancer spawns |
+| 3005 | Grinding Hall | G | Grinding wheels, gear grinder + saw sentinel |
+| 3006 | Mold Storage | M | Blade molds, blade dancer spawns |
+| 3007 | Component Stockpile | S | Construct parts, saw sentinel spawns |
+| 3008 | Quality Control | Q | Testing area, gear grinder + blade dancer |
+| 3009 | Tempering Pools | T | Quenching pools, saw sentinel spawns |
+| 3010 | The Assembly Line | A | Production floor, gear grinder + saw sentinel |
+| 3011 | Foreman's Office | O | Lore room, foundry blade stash |
+| 3012 | The Dueling Gallery | % | DUAL-WIELD TRAINER (1-4)! |
+
+*Hardmode - Hall of Endless Blades (Levels 11-15):*
+| Room ID | Name | Symbol | Features |
+|---------|------|--------|----------|
+| 3013 | The Blade Gate | # | Transition point, steam golem spawn |
+| 3014 | Proving Grounds | P | Combat arena, steam golem + gear grinder |
+| 3015 | The Weapon Vault | $ | BLADE MERCHANT! Hidden treasures |
+| 3016 | Steam Works | B | Boiler room, steam golem spawns |
+| 3017 | The Blade Garden | W | Swords growing like flowers! |
+| 3018 | Control Nexus | C | Crystal matrices, steam golem spawn |
+| 3019 | Master's Study | L | Lore, three-bladed sword blueprints |
+| 3020 | Hall of Endless Blades | X | BOSS ROOM - Voltaic Promethean! |
+
+**Mobs Created (7 total):**
+| Mob ID | Name | Level | Type | Notes |
+|--------|------|-------|------|-------|
+| 75 | Blade Dancer | 6 | Construct | FAST AGGRO, dual daggers, low HP |
+| 76 | Saw Sentinel | 8 | Construct | Circular blade arms, defensive |
+| 77 | Gear Grinder | 9 | Construct | Mobile grinding machine, area denial |
+| 78 | Steam Golem | 11 | Construct | Hulking, heavy hits, steam vents |
+| 79 | Voltaic Promethean | 15 | Construct | ZONE BOSS! Lightning + blades! |
+| 80 | Dual-Wield Instructor | 20 | Human | Skill trainer NPC |
+| 81 | Blade Merchant | 15 | Human | Sells foundry weapons |
+
+**Items Created (6 total):**
+| Item ID | Name | Type | Notes |
+|---------|------|------|-------|
+| 10021 | Foundry Blade | Weapon | 1d8 slashing, +1 STR |
+| 10022 | Serrated Saw Blade | Weapon | 2d4 slashing, +1 SPD |
+| 10023 | Piston Mace | Weapon | 2d6 bludgeoning, +2 STR, 2-handed |
+| 10024 | Three-Bladed Sword | Weapon | 2d6 slashing, +2 STR, +1 SPD - LEGENDARY! |
+| 10025 | Voltaic Blade | Weapon | 2d8 slashing, +2 STR, +2 SPD, +1 SMT - BOSS DROP! |
+| 20048 | Promethean Chassis | Body | +2 STR, +3 VIT, +1 SPD - BOSS ARMOR! |
+
+**Skill Training Added:**
+- **dual-wield** skill now trainable at The Dueling Gallery (Room 3012), levels 1-4!
+
+**Design Highlights:**
+- Fast aggro constructs in early rooms discourage underleveled players sneaking to trainer
+- Sword-shaped chandeliers EVERYWHERE as decorative element
+- Industrial atmospheric idle messages (grinding gears, steam hissing, blade sounds)
+- Environmental hazards (spinning wall saws, furnaces, tempering pools)
+- Two-tier difficulty with clear transition point (The Blade Gate)
+- Hidden Blade Merchant rewards explorers who brave hardmode
+- Mysterious Three-Bladed Sword as a signature item (placeholder stats per spec)
+- Voltaic Promethean boss with lightning + blade theme
+
+**Campaign Impact:**
+- Dual-wield now has SECOND training location! (Also in Dueling Hall 1012)
+- Warriors and Assassins have more progression options
+- Level 6-15 content added (fills gap between Catacombs and late game)
+- New boss fight for mid-level parties
+
+**Files Created:**
+- `_datafiles/world/default/rooms/bladeworks_foundry/zone-config.yaml`
+- `_datafiles/world/default/rooms/bladeworks_foundry/3001.yaml` through `3020.yaml`
+- `_datafiles/world/default/mobs/bladeworks_foundry/75-blade_dancer.yaml`
+- `_datafiles/world/default/mobs/bladeworks_foundry/76-saw_sentinel.yaml`
+- `_datafiles/world/default/mobs/bladeworks_foundry/77-gear_grinder.yaml`
+- `_datafiles/world/default/mobs/bladeworks_foundry/78-steam_golem.yaml`
+- `_datafiles/world/default/mobs/bladeworks_foundry/79-voltaic_promethean.yaml`
+- `_datafiles/world/default/mobs/bladeworks_foundry/80-dual_wield_instructor.yaml`
+- `_datafiles/world/default/mobs/bladeworks_foundry/81-blade_merchant.yaml`
+- `_datafiles/world/default/items/weapons-10000/10021-foundry_blade.yaml`
+- `_datafiles/world/default/items/weapons-10000/10022-serrated_saw_blade.yaml`
+- `_datafiles/world/default/items/weapons-10000/10023-piston_mace.yaml`
+- `_datafiles/world/default/items/weapons-10000/10024-three_bladed_sword.yaml`
+- `_datafiles/world/default/items/weapons-10000/10025-voltaic_blade.yaml`
+- `_datafiles/world/default/items/armor-20000/body/20048-promethean_chassis.yaml`
+
+**Files Modified:**
+- `_datafiles/world/default/rooms/whispering_wastes/168.yaml` - Added south exit to Bladeworks Foundry, new nouns for foundry hints
+
+*"THE FORGE FIRES BURN ETERNAL! The blade dancers spin their deadly dance! The Voltaic Promethean awaits in its hall of a thousand swords! BERT HAS SPOKEN AND THE BLADEWORKS FOUNDRY HAS ANSWERED!"*
+
+*Galstaff slams his staff against the anvil, and sparks of destiny fly into the night.*
+
+**For Bert. May his vision of EVERYTHING IS SWORDS live forever in the game.**
 
 ---

--- a/_datafiles/world/default/items/armor-20000/body/20048-promethean_chassis.yaml
+++ b/_datafiles/world/default/items/armor-20000/body/20048-promethean_chassis.yaml
@@ -1,0 +1,16 @@
+itemid: 20048
+name: promethean chassis
+namesimple: chassis
+description: This suit of armor was forged from salvaged plates of the Voltaic
+  Promethean's body. The interlocking blade-panels provide exceptional
+  protection while allowing full range of motion. Residual electrical energy
+  crackles across its surface, and the armor seems to repair minor damage
+  on its own over time. Wearing it fills you with a strange confidence,
+  as if the Promethean's indomitable will has become your own.
+type: armor
+subtype: body
+value: 3500
+statmods:
+  strength: 2
+  vitality: 3
+  speed: 1

--- a/_datafiles/world/default/items/weapons-10000/10021-three_bladed_sword.yaml
+++ b/_datafiles/world/default/items/weapons-10000/10021-three_bladed_sword.yaml
@@ -1,0 +1,15 @@
+itemid: 10021
+name: three-bladed sword
+namesimple: unusual sword
+description: An impractical but undeniably impressive weapon featuring three parallel
+  blades welded to a single hilt. The merchant who sold this swore each blade was
+  worth exactly one hundred gold. The awkward balance makes it slower to swing, but
+  you have to admit - it looks absolutely magnificent.
+type: weapon
+hands: 1
+subtype: slashing
+damage:
+  diceroll: 1d6
+statmods:
+  speed: -2
+value: 300

--- a/_datafiles/world/default/items/weapons-10000/10022-serrated_saw_blade.yaml
+++ b/_datafiles/world/default/items/weapons-10000/10022-serrated_saw_blade.yaml
@@ -1,0 +1,15 @@
+itemid: 10022
+name: serrated saw blade
+namesimple: saw blade
+description: This wicked weapon was salvaged from a destroyed saw sentinel. Its
+  edge is lined with cruel teeth designed to tear rather than cut cleanly.
+  The blade still vibrates faintly when swung, remnant energy from its
+  mechanical origins.
+type: weapon
+hands: 1
+subtype: slashing
+damage:
+  diceroll: 2d4
+value: 300
+statmods:
+  speed: 1

--- a/_datafiles/world/default/items/weapons-10000/10023-piston_mace.yaml
+++ b/_datafiles/world/default/items/weapons-10000/10023-piston_mace.yaml
@@ -1,0 +1,14 @@
+itemid: 10023
+name: piston mace
+namesimple: mace
+description: This heavy weapon was once part of a steam golem's arm. The piston
+  mechanism still functions, adding extra force to each swing. Small vents
+  release puffs of residual steam with every strike.
+type: weapon
+hands: 2
+subtype: bludgeoning
+damage:
+  diceroll: 2d6
+value: 450
+statmods:
+  strength: 2

--- a/_datafiles/world/default/items/weapons-10000/10025-voltaic_blade.yaml
+++ b/_datafiles/world/default/items/weapons-10000/10025-voltaic_blade.yaml
@@ -1,0 +1,19 @@
+itemid: 10025
+name: voltaic blade
+namesimple: blade
+description: This crackling sword was forged from the remains of the Voltaic
+  Promethean itself. Lightning constantly arcs along its edge, leaving
+  afterimages in the air with every swing. The blade seems almost alive,
+  humming with electrical energy that responds to its wielder's emotions.
+  Those who wield it report feeling a strange connection to the foundry
+  itself, as if the Promethean's consciousness lingers within the steel.
+type: weapon
+hands: 1
+subtype: slashing
+damage:
+  diceroll: 2d8
+value: 5000
+statmods:
+  strength: 2
+  speed: 2
+  smarts: 1

--- a/_datafiles/world/default/items/weapons-10000/10026-foundry_blade.yaml
+++ b/_datafiles/world/default/items/weapons-10000/10026-foundry_blade.yaml
@@ -1,0 +1,15 @@
+itemid: 10026
+name: foundry blade
+namesimple: blade
+description: A well-crafted sword forged in the Bladeworks Foundry. Its edge is
+  remarkably sharp and its balance perfect, a testament to the foundry's
+  legendary quality control. The blade bears a small maker's mark - crossed
+  hammers over an anvil.
+type: weapon
+hands: 1
+subtype: slashing
+damage:
+  diceroll: 1d8
+value: 150
+statmods:
+  strength: 1

--- a/_datafiles/world/default/mobs/bladeworks_foundry/75-blade_dancer.yaml
+++ b/_datafiles/world/default/mobs/bladeworks_foundry/75-blade_dancer.yaml
@@ -1,0 +1,38 @@
+mobid: 75
+zone: Bladeworks Foundry
+itemdropchance: 10
+hostile: true
+maxwander: 3
+groups:
+  - bladeworks-construct
+  - fast-aggro
+idlecommands:
+  - emote spins its dagger arms in a deadly flourish.
+  - emote clicks and whirs, seeking targets.
+  - emote performs a complex blade kata, edges gleaming.
+  - ""
+  - ""
+combatcommands:
+  - 'emote spins into a whirlwind of flashing blades!'
+  - 'emote leaps backward, then lunges with both daggers!'
+  - 'emote clicks excitedly as it finds an opening!'
+activitylevel: 25
+character:
+  name: blade dancer
+  description: This sleek construct was designed for speed and precision above all
+    else. Its body is a narrow frame of articulated steel, giving it uncanny
+    agility and grace. Where hands should be, twin daggers extend directly from
+    its wrists, permanently affixed and razor-sharp. Its legs are spring-loaded
+    for quick lunges and rapid retreats. A single glowing red eye serves as
+    both sensor and soul, tracking movement with predatory intensity. The blade
+    dancer was meant to demonstrate the foundry's products - now it demonstrates
+    only violence.
+  raceid: 22
+  level: 6
+  alignment: -20
+  gold: 5
+  equipment:
+    weapon:
+      itemid: 10004
+    offhand:
+      itemid: 10004

--- a/_datafiles/world/default/mobs/bladeworks_foundry/76-saw_sentinel.yaml
+++ b/_datafiles/world/default/mobs/bladeworks_foundry/76-saw_sentinel.yaml
@@ -1,0 +1,37 @@
+mobid: 76
+zone: Bladeworks Foundry
+itemdropchance: 15
+hostile: true
+maxwander: 2
+groups:
+  - bladeworks-construct
+  - defensive
+idlecommands:
+  - emote rotates its saw-arms slowly, testing their spin.
+  - emote scans the area with multiple optical sensors.
+  - emote rolls forward a few feet, then stops to listen.
+  - ""
+combatcommands:
+  - 'emote revs its circular blades to maximum speed!'
+  - 'emote interposes its spinning saws as a defensive barrier!'
+  - 'emote grinds forward relentlessly, sparks flying!'
+activitylevel: 15
+character:
+  name: saw sentinel
+  description: Built for defense and area denial, the saw sentinel is a rolling
+    fortress of spinning death. Its lower body is mounted on heavy treads that
+    allow it to move with surprising stability. Both arms terminate in massive
+    circular saw blades that can spin at tremendous speeds, creating an
+    impassable barrier of cutting edges. Its torso is heavily armored, designed
+    to withstand punishment while it holds its ground. Multiple optical sensors
+    give it 360-degree awareness. The saw sentinel was meant to guard high-value
+    areas - and it still does, though its masters are long gone.
+  raceid: 22
+  level: 8
+  alignment: -20
+  gold: 12
+  equipment:
+    weapon:
+      itemid: 10001
+    body:
+      itemid: 20012

--- a/_datafiles/world/default/mobs/bladeworks_foundry/77-gear_grinder.yaml
+++ b/_datafiles/world/default/mobs/bladeworks_foundry/77-gear_grinder.yaml
@@ -1,0 +1,36 @@
+mobid: 77
+zone: Bladeworks Foundry
+itemdropchance: 15
+hostile: true
+maxwander: 1
+groups:
+  - bladeworks-construct
+  - area-denial
+idlecommands:
+  - emote grinds its internal gears with a terrible screech.
+  - emote rotates its grinding plates experimentally.
+  - emote vents metal shavings from its processing chamber.
+  - ""
+combatcommands:
+  - 'emote opens its maw wide, grinding gears screaming for metal!'
+  - 'emote lurches forward, attempting to catch prey in its grinders!'
+  - 'emote spits a shower of metal shavings and sparks!'
+  - 'callforhelp 2:blade dancer:lets out a grinding shriek that echoes through the foundry!'
+activitylevel: 10
+character:
+  name: gear grinder
+  description: This nightmarish construct was designed to recycle damaged equipment
+    and failed weapons. Its body is essentially a mobile grinding machine - a
+    massive central cavity filled with interlocking gear-teeth that can reduce
+    solid steel to shavings in seconds. Heavy treads support its bulk, and
+    multiple grabbing arms can seize objects (or victims) and feed them into
+    its grinding maw. The gear grinder moves slowly but inexorably, and the
+    screech of its internal mechanisms can be heard throughout the foundry.
+    It no longer distinguishes between scrap metal and living intruders.
+  raceid: 22
+  level: 9
+  alignment: -30
+  gold: 15
+  equipment:
+    body:
+      itemid: 20012

--- a/_datafiles/world/default/mobs/bladeworks_foundry/78-steam_golem.yaml
+++ b/_datafiles/world/default/mobs/bladeworks_foundry/78-steam_golem.yaml
@@ -1,0 +1,40 @@
+mobid: 78
+zone: Bladeworks Foundry
+itemdropchance: 20
+hostile: true
+maxwander: 2
+groups:
+  - bladeworks-construct
+  - heavy-hitter
+idlecommands:
+  - emote vents steam from its shoulder joints with a hiss.
+  - emote takes heavy, clanking steps, shaking the floor.
+  - emote's pressure gauge needle twitches into the red.
+  - ""
+combatcommands:
+  - 'emote releases a scalding blast of steam from its vents!'
+  - 'emote swings a massive piston-driven fist!'
+  - 'emote roars with the sound of a hundred boilers!'
+  - 'emote overcharges its boiler, glowing red-hot!'
+activitylevel: 12
+character:
+  name: steam golem
+  description: The steam golem represents the pinnacle of the foundry's heavy
+    combat designs. Standing ten feet tall, its body is a walking boiler system
+    - brass and iron plates encase a superheated steam engine that powers its
+    every movement. Piston-driven arms can deliver crushing blows, and vents
+    throughout its body can release scalding steam as both weapon and defense.
+    A constant hiss accompanies its movements as pressure is vented and built
+    in an endless cycle. The steam golem's chest cavity glows orange with
+    internal heat, and its eye-lenses are fogged with its own moisture.
+  raceid: 22
+  level: 11
+  alignment: -30
+  gold: 35
+  equipment:
+    weapon:
+      itemid: 10003
+    body:
+      itemid: 20012
+    head:
+      itemid: 20007

--- a/_datafiles/world/default/mobs/bladeworks_foundry/79-voltaic_promethean.yaml
+++ b/_datafiles/world/default/mobs/bladeworks_foundry/79-voltaic_promethean.yaml
@@ -1,0 +1,56 @@
+mobid: 79
+zone: Bladeworks Foundry
+itemdropchance: 100
+hostile: true
+maxwander: 0
+groups:
+  - bladeworks-construct
+  - zone-boss
+idlecommands:
+  - emote crackles with lightning, arcs jumping between its blade-covered form.
+  - emote turns its head slowly, scanning for intruders.
+  - say WHO DARES ENTER THE HALL OF ENDLESS BLADES?
+  - emote raises one massive arm, electricity dancing along its fingers.
+  - emote's internal dynamo hums with barely contained power.
+combatcommands:
+  - 'emote channels lightning through its blade-arms in a devastating strike!'
+  - 'emote slams the ground, sending electricity arcing across the floor!'
+  - 'emote overloads, releasing a blinding pulse of electrical energy!'
+  - 'emote roars with a sound like thunder and grinding gears!'
+  - 'callforhelp 2:steam golem:sends a surge of power through the foundry''s systems!'
+activitylevel: 15
+character:
+  name: Voltaic Promethean
+  description: The Voltaic Promethean is the foundry's ultimate creation, a
+    fifteen-foot titan of steel and lightning that was meant to revolutionize
+    both warfare and industry. Its body is covered in interlocking blades that
+    serve as both armor and weapon, each one capable of channeling the electrical
+    energy that animates its form. A central dynamo in its chest generates
+    constant power, visible through gaps in its armor as crackling blue-white
+    lightning. Its eyes are twin orbs of pure electrical discharge, seeing
+    through currents rather than light. The Promethean was designed to think,
+    to create, to forge new weapons from raw materials using only its own body.
+    Instead, it became the instrument of the foundry's downfall - a creation
+    too powerful to control, too intelligent to serve. Now it rules the Hall
+    of Endless Blades, a steel god awaiting challengers.
+  raceid: 22
+  level: 15
+  alignment: -50
+  gold: 200
+  equipment:
+    weapon:
+      itemid: 10003
+    offhand:
+      itemid: 10003
+    body:
+      itemid: 20012
+    head:
+      itemid: 20018
+    neck:
+      itemid: 20017
+  items:
+    - itemid: 10025
+    - itemid: 20048
+hates:
+  - thieves
+  - assassins

--- a/_datafiles/world/default/mobs/bladeworks_foundry/80-dual_wield_instructor.yaml
+++ b/_datafiles/world/default/mobs/bladeworks_foundry/80-dual_wield_instructor.yaml
@@ -1,0 +1,40 @@
+mobid: 80
+zone: Bladeworks Foundry
+itemdropchance: 2
+hostile: false
+maxwander: 0
+groups:
+  - bladeworks-npc
+idlecommands:
+  - 'say I can help you <ansi fg="command">train</ansi> in the art of dual-wielding.'
+  - 'say Two blades are better than one, if you know how to use them.'
+  - emote demonstrates a complex dual-blade technique.
+  - emote parries an imaginary strike with one blade while riposting with the other.
+  - 'say The constructs here make excellent practice. Fast, aggressive, predictable.'
+  - 'say I survived the foundry''s fall. Now I teach others to do the same.'
+activitylevel: 20
+character:
+  name: dual-wield instructor
+  description: This weathered warrior is one of the few survivors of the Bladeworks
+    Foundry's catastrophic fall. Her arms bear the scars of countless blade wounds,
+    yet she moves with fluid grace that speaks of decades of training. She wears
+    practical leather armor reinforced with metal plates scavenged from destroyed
+    constructs. At her hips hang twin swords of exceptional quality, their edges
+    mirror-bright despite years of use. Her eyes constantly scan for threats,
+    a habit born of surviving in a place where everything wants to kill you.
+    She remained here not out of madness, but out of purpose - the Dueling
+    Gallery is the finest training ground for dual-wielding in the known world,
+    and she will not abandon it to the machines.
+  raceid: 1
+  level: 20
+  alignment: 25
+  gold: 50
+  equipment:
+    weapon:
+      itemid: 10007
+    offhand:
+      itemid: 10007
+    body:
+      itemid: 20030
+    feet:
+      itemid: 20003

--- a/_datafiles/world/default/mobs/bladeworks_foundry/81-blade_merchant.yaml
+++ b/_datafiles/world/default/mobs/bladeworks_foundry/81-blade_merchant.yaml
@@ -1,0 +1,52 @@
+mobid: 81
+zone: Bladeworks Foundry
+itemdropchance: 2
+hostile: false
+maxwander: 0
+groups:
+  - bladeworks-npc
+idlecommands:
+  - 'say Type <ansi fg="command">list</ansi> to see my wares.'
+  - 'say I deal in the foundry''s finest creations. Quality has a price.'
+  - emote polishes a blade with a soft cloth.
+  - 'say The Three-Bladed Sword? Ah, yes. A masterwork of the old artificers.'
+  - emote glances nervously toward the exits.
+  - 'say I risk my life to sell these treasures. The least you can do is buy something.'
+activitylevel: 15
+character:
+  name: blade merchant
+  description: This cloaked figure has made a dangerous living salvaging and selling
+    weapons from the depths of the Bladeworks Foundry. Their face is hidden beneath
+    a deep hood, and their hands are covered in thick leather gloves scarred by
+    countless small cuts. A massive pack on their back clinks with metal, filled
+    with blades of every description. They move with the careful, quiet steps
+    of someone who has learned to avoid the attention of constructs. Despite
+    the danger, they seem almost cheerful - the foundry's lost treasures fetch
+    incredible prices, and they have exclusive access to the supply. The blade
+    merchant knows every safe route through the foundry, every hiding spot, and
+    every construct patrol pattern.
+  raceid: 1
+  level: 15
+  alignment: 0
+  gold: 500
+  shop:
+    - itemid: 10004
+      quantitymax: 5
+    - itemid: 10007
+      quantitymax: 3
+    - itemid: 10021
+      quantity: 3
+      quantitymax: 3
+      restockrate: 100 years
+      price: 300
+    - itemid: 10022
+      quantitymax: 2
+    - itemid: 10023
+      quantitymax: 1
+  equipment:
+    weapon:
+      itemid: 10005
+    body:
+      itemid: 20030
+    neck:
+      itemid: 20002

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3001.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3001.yaml
@@ -1,0 +1,31 @@
+roomid: 3001
+zone: Bladeworks Foundry
+title: Foundry Entrance
+description: A massive iron door, scarred by countless blade-strikes, hangs half-open
+  on rusted hinges. Beyond lies the Bladeworks Foundry, a once-legendary weapons
+  manufactory now fallen to ruin and overrun by its own creations. The walls are
+  lined with decorative sword displays, though many blades have been torn from
+  their mounts. A sword-shaped chandelier hangs crookedly overhead, its glass
+  blade-arms casting fractured light across the dusty floor. The air is thick
+  with the smell of old oil and hot metal. Faded signs warn of "AUTHORIZED
+  ARTIFICERS ONLY" and "BLADE HAZARD ZONE."
+mapsymbol: E
+maplegend: Entrance
+biome: dungeon
+exits:
+  north:
+    roomid: 168
+  south:
+    roomid: 3002
+nouns:
+  door: The iron door bears deep gouges from bladed weapons. Whatever happened
+    here, it was violent and sudden.
+  chandelier: A chandelier crafted entirely from sword-shaped glass hangs precariously.
+    Each glass blade catches the dim light, creating dancing reflections.
+  signs: Weathered signs warn of industrial hazards. One reads "Construct Testing
+    in Progress - Do Not Disturb."
+idlemessages:
+- The iron door creaks in an unseen draft.
+- A glass blade from the chandelier falls and shatters on the stone floor.
+- Something mechanical whirs to life deeper within the foundry.
+- The temperature rises noticeably, heat radiating from the south.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3002.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3002.yaml
@@ -1,0 +1,36 @@
+roomid: 3002
+zone: Bladeworks Foundry
+title: The Receiving Bay
+description: This cavernous chamber once received raw materials for the foundry's
+  hungry forges. Rusted conveyor belts stretch across the floor like metal
+  serpents, some still jerking forward in fits and starts. Crates of unprocessed
+  ore and ingots lie scattered about, many torn open by mechanical claws. Along
+  the walls, sorting machines click and whir mindlessly, their gears grinding
+  without purpose. A sword-chandelier hangs from chains above, its glass blades
+  still intact and glowing faintly from the forge-light that filters in from
+  the south.
+mapsymbol: '.'
+biome: dungeon
+exits:
+  north:
+    roomid: 3001
+  south:
+    roomid: 3003
+  east:
+    roomid: 3004
+spawninfo:
+- mobid: 75
+  message: A blade dancer whirs out from behind a crate, daggers spinning.
+  respawnrate: 3 real minutes
+  maxcount: 2
+nouns:
+  conveyor: The conveyor belts move in sporadic bursts, still trying to fulfill
+    some long-forgotten sorting directive.
+  crates: The crates have been violently torn open. Raw ore and metal ingots
+    spill across the floor.
+  machines: The sorting machines continue their work endlessly, clicking and
+    whirring as they sort nothing at all.
+idlemessages:
+- A conveyor belt lurches forward with a grinding screech.
+- Metal ingots rattle in their crates as machinery vibrates.
+- A sorting machine whirs, then clicks in disappointment at finding nothing.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3003.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3003.yaml
@@ -1,0 +1,44 @@
+roomid: 3003
+zone: Bladeworks Foundry
+title: The Smelting Chamber
+description: Enormous furnaces line the walls of this sweltering chamber, their
+  fires still burning despite years of abandonment. Vats of molten metal glow
+  orange and red, bubbling with eternal heat. Mechanical arms hang from the
+  ceiling on tracks, designed to pour molten steel into blade molds below.
+  Some arms still jerk and twitch, splashing dangerous drops of liquid metal
+  across the floor. The sword-chandeliers here are made of actual metal blades,
+  their edges glinting wickedly in the forge-light. Catwalks crisscross overhead,
+  leading to controls that no longer have operators.
+mapsymbol: 'F'
+maplegend: Forge
+biome: dungeon
+exits:
+  north:
+    roomid: 3002
+  south:
+    roomid: 3005
+  west:
+    roomid: 3006
+spawninfo:
+- mobid: 75
+  message: A blade dancer drops from a catwalk, landing in a combat stance.
+  respawnrate: 4 real minutes
+  maxcount: 1
+- mobid: 76
+  message: A saw sentinel rolls out from behind a furnace, blades spinning.
+  respawnrate: 5 real minutes
+  maxcount: 1
+nouns:
+  furnaces: The furnaces burn with supernatural intensity. Whatever fuel powers
+    them has not run out in all these years.
+  vats: Vats of molten metal bubble and churn. The heat is nearly unbearable
+    this close.
+  arms: The mechanical arms twitch and jerk, occasionally pouring molten metal
+    into nothing at all.
+  catwalks: Iron catwalks span the chamber above, providing access to control
+    stations along the walls.
+idlemessages:
+- A furnace roars as its flames surge higher.
+- Molten metal bubbles and pops in the vats.
+- A mechanical arm swings overhead, dripping liquid steel.
+- The heat makes the air shimmer and dance.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3004.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3004.yaml
@@ -1,0 +1,33 @@
+roomid: 3004
+zone: Bladeworks Foundry
+title: Supply Corridor
+description: A narrow corridor connects the receiving bay to the storage areas.
+  The walls are lined with racks that once held tools and components, now mostly
+  empty or scattered across the floor. Spinning saw blades are embedded in the
+  walls at regular intervals, part of an old security system that still activates
+  sporadically. Glass sword-sconces provide flickering illumination, several
+  cracked and dark. The floor bears countless scratches from the passage of
+  metal feet.
+mapsymbol: '-'
+biome: dungeon
+exits:
+  west:
+    roomid: 3002
+  east:
+    roomid: 3007
+spawninfo:
+- mobid: 75
+  message: A blade dancer emerges from the shadows, daggers at the ready.
+  respawnrate: 3 real minutes
+  maxcount: 2
+nouns:
+  racks: Empty tool racks line the walls. Whatever was stored here has long
+    since been taken or destroyed.
+  saws: Circular saw blades spin in wall-mounted housings, a deadly security
+    measure that still functions erratically.
+  sconces: The glass sconces are shaped like upturned swords, their pommels
+    holding small flames.
+idlemessages:
+- A wall-mounted saw blade suddenly spins to life, then stops.
+- Glass crunches underfoot from a shattered sconce.
+- Something metallic scrapes against stone in the distance.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3005.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3005.yaml
@@ -1,0 +1,44 @@
+roomid: 3005
+zone: Bladeworks Foundry
+title: The Grinding Hall
+description: This long hall is dominated by massive grinding wheels mounted along
+  both walls. Some still spin slowly, their stone surfaces worn smooth from
+  sharpening countless blades. Sparks occasionally fly as errant metal scraps
+  are caught in the wheels. The floor is thick with metal filings that crunch
+  underfoot like iron snow. Overhead, a magnificent chandelier holds dozens of
+  finished swords arranged in a spiral pattern, turning slowly in the heat
+  rising from below. Water troughs run along the base of the grinders, meant
+  for cooling blades but now stagnant and rust-colored.
+mapsymbol: 'G'
+maplegend: Grinding
+biome: dungeon
+exits:
+  north:
+    roomid: 3003
+  south:
+    roomid: 3008
+  east:
+    roomid: 3009
+spawninfo:
+- mobid: 77
+  message: A gear grinder emerges from the metal filings, gears spinning ominously.
+  respawnrate: 5 real minutes
+  maxcount: 1
+- mobid: 76
+  message: A saw sentinel rolls forward, drawn by the sound of intruders.
+  respawnrate: 4 real minutes
+  maxcount: 1
+nouns:
+  wheels: The grinding wheels spin endlessly, their purpose forgotten but their
+    motion eternal.
+  filings: Metal filings coat the floor inches deep, the accumulated shavings
+    of countless sharpened blades.
+  chandelier: Dozens of finished swords hang in a spiral pattern, rotating
+    slowly like a deadly mobile.
+  troughs: Water troughs run rust-red, contaminated by years of iron filings
+    and neglect.
+idlemessages:
+- A grinding wheel screeches as it catches a metal scrap.
+- Sparks shower from a grinder, illuminating the gloom.
+- The sword chandelier turns, blades catching the light.
+- Metal filings shift and settle with a soft, metallic hiss.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3006.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3006.yaml
@@ -1,0 +1,34 @@
+roomid: 3006
+zone: Bladeworks Foundry
+title: Mold Storage
+description: Rows of heavy iron shelves fill this chamber, holding countless blade
+  molds of every conceivable design. Swords, daggers, axes, spears - the foundry
+  could produce any edged weapon imaginable. Some molds lie broken on the floor,
+  their forms cracked and useless. Others still hold cooled metal, half-formed
+  blades frozen in the process of creation. A thick layer of dust covers
+  everything, disturbed only by the tracks of wandering constructs. The
+  sword-chandelier here is particularly ornate, featuring miniature replicas
+  of famous legendary blades.
+mapsymbol: 'M'
+maplegend: Molds
+biome: dungeon
+exits:
+  east:
+    roomid: 3003
+spawninfo:
+- mobid: 75
+  message: A blade dancer steps out from between the shelves, weapons drawn.
+  respawnrate: 3 real minutes
+  maxcount: 2
+nouns:
+  shelves: Iron shelving units hold hundreds of blade molds, organized by weapon
+    type and size.
+  molds: The molds are made of hardened iron, shaped in negative to create
+    perfect blade forms.
+  blades: Half-finished blades sit forgotten in their molds, never to be completed.
+  chandelier: This chandelier holds tiny replicas of legendary swords - you
+    recognize the shapes of Excalibur, Durendal, and other mythic weapons.
+idlemessages:
+- A mold clatters as it falls from an unstable shelf.
+- Dust motes dance in the dim light filtering through the chamber.
+- Something scrapes against metal deeper in the storage area.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3007.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3007.yaml
@@ -1,0 +1,34 @@
+roomid: 3007
+zone: Bladeworks Foundry
+title: Component Stockpile
+description: This storage room once held the components needed to build the foundry's
+  construct workforce. Now it serves as a graveyard for damaged and defunct
+  machines. Piles of gears, springs, and mechanical limbs litter the floor.
+  Shelves hold jars of lubricating oils, most dried or congealed. A workbench
+  in the corner still has partially-assembled constructs lying upon it, frozen
+  mid-creation. The sword-chandelier here is made entirely of discarded blade
+  components - hilts, guards, and pommels arranged in artistic chaos.
+mapsymbol: 'S'
+maplegend: Storage
+biome: dungeon
+exits:
+  west:
+    roomid: 3004
+spawninfo:
+- mobid: 76
+  message: A saw sentinel assembles itself from spare parts and rises to attack.
+  respawnrate: 5 real minutes
+  maxcount: 1
+nouns:
+  gears: Gears of every size litter the floor, from tiny watch-springs to
+    massive drive wheels.
+  workbench: The workbench holds partially assembled constructs, their empty
+    eye-sockets staring at nothing.
+  shelves: Shelves of oils and lubricants line the walls, most containers
+    cracked or empty.
+  chandelier: This chandelier is assembled from sword components - hilts,
+    guards, and pommels forming an abstract sculpture.
+idlemessages:
+- Gears shift and settle, disturbed by vibrations from distant machinery.
+- A jar of oil slowly drips onto the floor with a soft plop.
+- One of the partial constructs on the workbench twitches, then falls still.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3008.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3008.yaml
@@ -1,0 +1,41 @@
+roomid: 3008
+zone: Bladeworks Foundry
+title: Quality Control Chamber
+description: This chamber was where the foundry's blades were tested and inspected.
+  Target dummies made of straw and leather stand in rows, all thoroughly
+  shredded by countless blade tests. Mechanical arms mounted on rails can swing
+  weapons at various speeds and angles, testing edge retention and balance.
+  Several arms still hold rusted blades, frozen mid-swing. Along one wall, a
+  rack displays blades that failed inspection - cracked, bent, or poorly
+  tempered. The sword-chandelier overhead is made from broken blades, a fitting
+  decoration for this chamber of imperfection.
+mapsymbol: 'Q'
+maplegend: QC
+biome: dungeon
+exits:
+  north:
+    roomid: 3005
+  south:
+    roomid: 3010
+spawninfo:
+- mobid: 77
+  message: A gear grinder rolls out from testing station, grinding blades spinning.
+  respawnrate: 5 real minutes
+  maxcount: 1
+- mobid: 75
+  message: A blade dancer drops from a testing arm, immediately attacking.
+  respawnrate: 3 real minutes
+  maxcount: 1
+nouns:
+  dummies: The target dummies have been reduced to ribbons and stuffing by
+    years of blade testing.
+  arms: Mechanical testing arms hold blades frozen in mid-swing, still waiting
+    for a command that will never come.
+  rack: A rack of failed blades shows the foundry's exacting standards - even
+    minor flaws meant rejection.
+  chandelier: This chandelier is made entirely from broken and rejected blades,
+    their flaws visible even from below.
+idlemessages:
+- A testing arm suddenly swings, slicing through empty air.
+- Straw drifts down from a shredded dummy.
+- A blade falls from the reject rack with a clatter.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3009.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3009.yaml
@@ -1,0 +1,36 @@
+roomid: 3009
+zone: Bladeworks Foundry
+title: Tempering Pools
+description: A series of deep pools fill this chamber, once used for quenching
+  and tempering hot-forged blades. Some pools still bubble with mysterious oils,
+  others hold stagnant water that gleams with metallic rainbows. Chains and
+  hooks hang from the ceiling, designed to lower blades into the pools with
+  precise timing. The walls are scorched from decades of hot metal being plunged
+  into liquid. A massive sword-chandelier hangs directly over the central pool,
+  its glass blades dripping with condensation from the steam that constantly
+  rises from below.
+mapsymbol: 'T'
+maplegend: Tempering
+biome: dungeon
+exits:
+  west:
+    roomid: 3005
+  south:
+    roomid: 3011
+spawninfo:
+- mobid: 76
+  message: A saw sentinel emerges from the steam, dripping with tempering oil.
+  respawnrate: 4 real minutes
+  maxcount: 1
+nouns:
+  pools: The tempering pools range from oil to water to mysterious alchemical
+    solutions. Some still bubble with residual heat.
+  chains: Heavy chains with blade-hooks hang from the ceiling, rusted but
+    still functional.
+  chandelier: The central chandelier drips constantly with condensation, its
+    glass blades weeping in the humid air.
+idlemessages:
+- Steam rises from a pool as something hot falls into it somewhere.
+- Chains rattle as the building settles.
+- Bubbles rise from the depths of an oil pool.
+- The chandelier drips steadily into the pool below.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3010.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3010.yaml
@@ -1,0 +1,43 @@
+roomid: 3010
+zone: Bladeworks Foundry
+title: The Assembly Line
+description: This is the heart of the foundry's production floor - a massive
+  assembly line where components came together to form finished weapons. Conveyor
+  belts crisscross the chamber at multiple levels, some still moving. Mechanical
+  arms stand poised at each station, ready to attach hilts, wrap handles, or
+  sharpen edges. Racks of partially completed weapons line the walls in various
+  states of assembly. The sword-chandeliers here hang in a row down the center
+  of the line, each one holding progressively more complete blade forms, from
+  raw metal to finished sword. This is where the constructs learned to build -
+  and eventually, to fight.
+mapsymbol: 'A'
+maplegend: Assembly
+biome: dungeon
+exits:
+  north:
+    roomid: 3008
+  south:
+    roomid: 3012
+spawninfo:
+- mobid: 77
+  message: A gear grinder detaches from the assembly line and advances.
+  respawnrate: 4 real minutes
+  maxcount: 2
+- mobid: 76
+  message: A saw sentinel rolls off a conveyor belt, blades spinning to life.
+  respawnrate: 4 real minutes
+  maxcount: 1
+nouns:
+  conveyor: The conveyor belts move weapons through each assembly stage, an
+    endless loop of production gone wrong.
+  arms: Mechanical assembly arms stand frozen at their stations, tools still
+    gripped and ready.
+  racks: Racks of incomplete weapons line the walls - blades without hilts,
+    hilts without guards, guards without pommels.
+  chandeliers: The chandeliers tell the story of blade creation - each one
+    holds progressively more complete weapons.
+idlemessages:
+- A conveyor belt lurches forward, carrying unfinished weapons toward nowhere.
+- An assembly arm twitches, attempting to work on empty air.
+- Metal parts clatter as they fall from an overloaded rack.
+- The chandeliers sway in rhythm with the machinery's vibrations.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3011.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3011.yaml
@@ -1,0 +1,32 @@
+roomid: 3011
+zone: Bladeworks Foundry
+title: Foreman's Office
+description: This small office overlooks the tempering pools through thick glass
+  windows, now cracked and grimy. A heavy desk sits in the center, covered with
+  yellowed production orders and inventory lists. The walls are decorated with
+  blueprints for various blade designs and construct schematics. A small
+  sword-chandelier hangs from the ceiling, its glass blades more delicate than
+  those in the production areas. This was where the foundry's foreman directed
+  operations - before the constructs turned on their masters.
+mapsymbol: 'O'
+maplegend: Office
+biome: dungeon
+exits:
+  north:
+    roomid: 3009
+nouns:
+  desk: The foreman's desk is covered with old paperwork - production quotas,
+    maintenance schedules, and one ominous note about "unusual construct behavior."
+  windows: Thick glass windows overlook the tempering pools below. Cracks
+    spiderweb across their surface.
+  blueprints: Blueprints for blade designs and construct schematics paper the
+    walls, some torn or defaced.
+  chandelier: This chandelier is more elegant than the industrial versions,
+    befitting an office space.
+stash:
+- itemid: 10021
+  chance: 25
+idlemessages:
+- Papers rustle in a draft from a crack in the window.
+- The chair behind the desk creaks as if someone just stood up.
+- Dust motes dance in the light filtering through the grimy windows.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3012.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3012.yaml
@@ -1,0 +1,44 @@
+roomid: 3012
+zone: Bladeworks Foundry
+title: The Dueling Gallery
+description: This elegant chamber stands in stark contrast to the industrial chaos
+  elsewhere in the foundry. Polished marble floors bear the scuffs of countless
+  practice bouts. Mirrors line the walls, allowing duelists to observe their
+  own form. Weapon racks hold an impressive array of training blades, many
+  designed for dual-wielding practice. At the far end, a raised platform serves
+  as an instructor's station. The sword-chandeliers here are masterworks -
+  actual functional blades suspended in perfect balance, ready to be drawn in
+  an emergency. This was where the foundry's artificers learned to TEST their
+  creations. Those who survived the deeper forges often came here to master
+  fighting with two blades at once.
+mapsymbol: '%'
+maplegend: Trainer
+biome: dungeon
+exits:
+  north:
+    roomid: 3010
+  south:
+    roomid: 3013
+    secret: true
+spawninfo:
+- mobid: 80
+  message: The dual-wield instructor steps down from the training platform.
+  respawnrate: 2 real minutes
+nouns:
+  mirrors: The mirrors are remarkably intact, showing reflections of your
+    stance from every angle.
+  racks: Training weapons fill the racks - paired daggers, matched swords,
+    and exotic dual-blade configurations.
+  platform: The instructor's platform has seen years of use. Marks on the
+    floor show where countless students have stood.
+  chandeliers: These chandeliers hold actual weapons, suspended in perfect
+    balance. They could be drawn and used in battle.
+skilltraining:
+  dual-wield:
+    min: 1
+    max: 4
+idlemessages:
+- Your reflection multiplies in the surrounding mirrors.
+- A training blade falls from its rack with a clatter.
+- The chandeliers sway gently, their suspended blades gleaming.
+- Echoes of ancient dueling commands seem to whisper from the walls.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3013.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3013.yaml
@@ -1,0 +1,36 @@
+roomid: 3013
+zone: Bladeworks Foundry
+title: The Blade Gate
+description: A massive gateway marks the transition from the production floors to
+  the deeper foundry. The gate itself is made entirely of interlocking swords,
+  their hilts forming the hinges and their blades the bars. It stands half-open,
+  jammed in place by the twisted body of a destroyed construct. Beyond, the air
+  grows hotter and the lighting more erratic. The sword-chandeliers past this
+  point are made of larger, more dangerous blades - clearly meant as weapons,
+  not decorations. A warning plaque beside the gate reads "HALL OF ENDLESS
+  BLADES - MASTER ARTIFICERS ONLY."
+mapsymbol: '#'
+maplegend: Gate
+biome: dungeon
+exits:
+  north:
+    roomid: 3012
+  south:
+    roomid: 3014
+spawninfo:
+- mobid: 78
+  message: A steam golem steps through the blade gate, venting hot vapor.
+  respawnrate: 6 real minutes
+  maxcount: 1
+nouns:
+  gate: The gate is an engineering marvel - hundreds of swords woven together
+    to form a functional barrier.
+  construct: A destroyed construct lies wedged in the gate, its metal body
+    twisted and torn.
+  plaque: The warning plaque's letters are scorched, as if emphasizing the
+    danger ahead.
+idlemessages:
+- The blade gate groans as the building settles.
+- Steam vents from somewhere beyond the gateway.
+- The destroyed construct creaks ominously in its metal grave.
+- Heat waves shimmer in the air beyond the gate.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3014.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3014.yaml
@@ -1,0 +1,44 @@
+roomid: 3014
+zone: Bladeworks Foundry
+title: The Proving Grounds
+description: This vast chamber was where the foundry's most powerful constructs
+  were tested in actual combat. The floor is scarred with blade marks and
+  gouged by heavy impacts. Destroyed constructs litter the edges of the room,
+  pushed aside to clear the fighting space. Blade-walls - spinning barriers
+  of razor-sharp metal - can emerge from slots in the floor, though most are
+  jammed or broken. The sword-chandeliers here are massive, holding great
+  swords and battle axes instead of mere daggers. Viewing galleries line the
+  upper walls, where artificers once watched their creations fight.
+mapsymbol: 'P'
+maplegend: Proving
+biome: dungeon
+exits:
+  north:
+    roomid: 3013
+  south:
+    roomid: 3015
+  east:
+    roomid: 3016
+spawninfo:
+- mobid: 78
+  message: A steam golem rises from the wreckage, ready for battle.
+  respawnrate: 5 real minutes
+  maxcount: 2
+- mobid: 77
+  message: A gear grinder rolls into the proving grounds, gears screaming.
+  respawnrate: 4 real minutes
+  maxcount: 1
+nouns:
+  floor: The floor bears the scars of countless battles - blade gouges, impact
+    craters, and rust stains that might be oil or blood.
+  constructs: Destroyed constructs are piled at the room's edges, a graveyard
+    of failed experiments.
+  galleries: Viewing galleries overlook the proving grounds, their seats dusty
+    and abandoned.
+  blade-walls: Slots in the floor once deployed spinning blade barriers. Most
+    are jammed, but some still twitch dangerously.
+idlemessages:
+- A blade-wall slot sparks and tries to deploy, then jams.
+- Metal debris shifts as something moves beneath the wreckage.
+- The great sword chandelier sways, its massive blades groaning.
+- Echoes of ancient battles seem to ring through the chamber.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3015.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3015.yaml
@@ -1,0 +1,41 @@
+roomid: 3015
+zone: Bladeworks Foundry
+title: The Weapon Vault
+description: Reinforced steel walls surround this chamber, designed to contain
+  the foundry's most valuable and dangerous creations. Display cases line the
+  walls, most smashed open and emptied. A few still hold weapons of remarkable
+  craftsmanship - blades that glow with inner light, edges that seem to cut
+  the very air. A hidden merchant has made their home here, trading in the
+  foundry's lost treasures to those brave enough to reach this deep. The
+  sword-chandelier here is made of the foundry's finest work - masterwork
+  blades that sing when air passes through them.
+mapsymbol: '$'
+maplegend: Merchant
+biome: dungeon
+exits:
+  north:
+    roomid: 3014
+  west:
+    roomid: 3017
+spawninfo:
+- mobid: 81
+  message: The blade merchant emerges from behind a display case.
+  respawnrate: 2 real minutes
+nouns:
+  cases: The display cases once held the foundry's finest work. Most are empty
+    now, their treasures looted or destroyed.
+  weapons: A few weapons remain - blades of exceptional quality that glow with
+    residual enchantment.
+  walls: The reinforced walls bear marks where thieves tried and failed to
+    break through from outside.
+  chandelier: This chandelier's blades are the finest in the foundry - they
+    hum musically when disturbed.
+stash:
+- itemid: 10022
+  chance: 15
+- itemid: 10023
+  chance: 10
+idlemessages:
+- The masterwork chandelier hums a haunting melody.
+- Light glints off a blade still locked in its case.
+- The heavy vault door creaks in its frame.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3016.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3016.yaml
@@ -1,0 +1,38 @@
+roomid: 3016
+zone: Bladeworks Foundry
+title: Steam Works
+description: Massive boilers and pipes fill this chamber, the power source for the
+  entire foundry. Steam vents from countless joints and valves, creating a
+  perpetual fog that obscures vision. The heat is nearly unbearable, and the
+  constant hiss of escaping pressure makes communication difficult. Catwalks
+  span the pipes at multiple levels, many rusted through and dangerous. This
+  is where the steam golems were born, their bodies filled with superheated
+  vapor from these eternal boilers. The sword-chandeliers here are made of
+  burnished bronze, resistant to the corrosive steam.
+mapsymbol: 'B'
+maplegend: Boilers
+biome: dungeon
+exits:
+  west:
+    roomid: 3014
+  south:
+    roomid: 3018
+spawninfo:
+- mobid: 78
+  message: A steam golem emerges from the clouds of vapor.
+  respawnrate: 4 real minutes
+  maxcount: 2
+nouns:
+  boilers: The massive boilers burn with an eternal flame, producing steam
+    that powers the entire foundry.
+  pipes: A maze of pipes carries steam throughout the facility, many leaking
+    or burst.
+  catwalks: Rusted catwalks provide precarious access to the upper machinery.
+    Several have collapsed entirely.
+  vents: Steam vents release pressure at random intervals, creating scalding
+    geysers.
+idlemessages:
+- A steam vent releases with a deafening hiss.
+- Condensation drips from every surface.
+- The boilers rumble ominously, pressure building.
+- Visibility drops as a wave of steam rolls through.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3017.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3017.yaml
@@ -1,0 +1,40 @@
+roomid: 3017
+zone: Bladeworks Foundry
+title: The Blade Garden
+description: This chamber defies explanation - thousands of swords grow from the
+  floor like metal flowers, their blades reaching toward the ceiling in eerie
+  stillness. This was an experiment by the foundry's master artificers, an
+  attempt to grow weapons rather than forge them. The experiment succeeded
+  beyond their wildest dreams - and worst nightmares. The blades continue to
+  grow, slowly filling the chamber over decades. Walking here requires extreme
+  care, as blades sprout everywhere. The sword-chandeliers are unnecessary -
+  the blade-flowers themselves catch and reflect light throughout the chamber.
+mapsymbol: 'W'
+maplegend: Garden
+biome: dungeon
+exits:
+  east:
+    roomid: 3015
+  south:
+    roomid: 3019
+spawninfo:
+- mobid: 78
+  message: A steam golem carefully picks its way through the blade garden.
+  respawnrate: 5 real minutes
+  maxcount: 1
+- mobid: 77
+  message: A gear grinder crushes through the blade-flowers, destroying several.
+  respawnrate: 5 real minutes
+  maxcount: 1
+nouns:
+  blades: The blade-flowers grow in impossibly delicate formations, their
+    edges sharp enough to cut on contact.
+  floor: The floor is barely visible beneath the forest of growing blades.
+    Each step must be planned carefully.
+  experiment: Signs of the original experiment remain - alchemical residue,
+    growth chambers, and notes about "metallurgical botany."
+idlemessages:
+- A blade-flower grows a fraction of an inch with a soft ringing sound.
+- Light dances across the chamber, reflected by countless edges.
+- A gentle chime rings as blades touch in the stillness.
+- New blade-buds push up through the floor with tiny metallic pings.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3018.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3018.yaml
@@ -1,0 +1,38 @@
+roomid: 3018
+zone: Bladeworks Foundry
+title: The Control Nexus
+description: This chamber houses the magical and mechanical systems that control
+  the foundry's constructs. Crystal matrices pulse with arcane energy, connected
+  to copper wires that snake throughout the building. Control panels line the
+  walls, their levers and dials still active. This is where the constructs
+  received their orders - and where, presumably, something went terribly wrong.
+  A massive central crystal, cracked and flickering, seems to be the source
+  of the constructs' continued animation. The sword-chandeliers here incorporate
+  crystal elements, their blades humming with residual magical energy.
+mapsymbol: 'C'
+maplegend: Control
+biome: dungeon
+exits:
+  north:
+    roomid: 3016
+  south:
+    roomid: 3020
+spawninfo:
+- mobid: 78
+  message: A steam golem steps away from a control panel, venting pressure.
+  respawnrate: 5 real minutes
+  maxcount: 1
+nouns:
+  matrices: Crystal matrices pulse with arcane energy, the magical heart of
+    the construct control system.
+  panels: Control panels display readings and accept inputs, though their
+    purposes are no longer clear.
+  crystal: The central crystal is cracked but still functional. Its light
+    pulses in rhythm with construct activity throughout the foundry.
+  wires: Copper wires thick as arms snake from the crystal to every corner
+    of the facility.
+idlemessages:
+- A crystal matrix pulses brighter, then dims.
+- Control panel dials spin without input.
+- The central crystal flickers, and distant constructs pause momentarily.
+- Arcane energy crackles along the copper wiring.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3019.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3019.yaml
@@ -1,0 +1,35 @@
+roomid: 3019
+zone: Bladeworks Foundry
+title: The Master's Study
+description: This was the private study of the foundry's master artificer, the
+  genius who designed the constructs and dreamed of a world where weapons forged
+  themselves. Bookshelves line the walls, filled with treatises on metallurgy,
+  construct animation, and blade enchantment. A massive desk holds unfinished
+  designs - the last projects the master was working on before the uprising.
+  One blueprint shows a three-bladed sword, its design revolutionary but
+  incomplete. The sword-chandelier here is a personal masterwork, holding the
+  artificer's own collection of experimental blades.
+mapsymbol: 'L'
+maplegend: Library
+biome: dungeon
+exits:
+  north:
+    roomid: 3017
+  east:
+    roomid: 3020
+nouns:
+  bookshelves: The shelves hold the accumulated knowledge of generations of
+    artificers - a priceless library of bladecraft.
+  desk: The desk is covered with half-finished designs, including one for a
+    revolutionary three-bladed weapon.
+  blueprints: The blueprints show weapons of incredible complexity - some
+    clearly impossible, others merely very difficult.
+  chandelier: This chandelier holds the artificer's personal collection -
+    blades of unique design found nowhere else.
+stash:
+- itemid: 10024
+  chance: 5
+idlemessages:
+- A book falls open, its pages yellowed with age.
+- Dust motes dance in the light from the crystal chandelier.
+- The designs on the desk seem to rearrange themselves when you look away.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/3020.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/3020.yaml
@@ -1,0 +1,43 @@
+roomid: 3020
+zone: Bladeworks Foundry
+title: The Hall of Endless Blades
+description: You have entered the legendary Hall of Endless Blades, the chamber
+  that gave this dungeon its fearsome reputation. The walls, floor, and ceiling
+  are covered - no, MADE of blades. Swords of every design interlock to form
+  the very structure of the room. In the center stands the Voltaic Promethean,
+  the foundry's ultimate creation - a towering construct of gleaming steel and
+  crackling lightning, its form a perfect fusion of blade and electricity. This
+  was meant to be the foundry's masterpiece, a construct that could forge,
+  fight, and think. Instead, it became their doom. The sword-chandelier above
+  is the largest in the foundry - a spiral of a thousand blades descending from
+  the ceiling, crackling with the same lightning that animates the Promethean.
+mapsymbol: 'X'
+maplegend: Boss
+biome: dungeon
+exits:
+  west:
+    roomid: 3019
+  north:
+    roomid: 3018
+spawninfo:
+- mobid: 79
+  message: The Voltaic Promethean awakens, lightning arcing across its blade-covered form!
+  respawnrate: 15 real minutes
+nouns:
+  walls: The walls are constructed entirely from interlocking swords - a feat
+    of engineering that borders on madness.
+  promethean: The Voltaic Promethean stands fifteen feet tall, its body a
+    fusion of finest steel and living lightning.
+  chandelier: A thousand blades spiral down from the ceiling, crackling with
+    electrical energy that links to the Promethean below.
+stash:
+- itemid: 10025
+  chance: 100
+- itemid: 20048
+  chance: 50
+idlemessages:
+- Lightning arcs between the blade-walls with a deafening crack.
+- The Promethean's eyes glow brighter, scanning for threats.
+- Electricity dances down the spiral chandelier.
+- The entire room hums with barely contained power.
+- Blades in the walls vibrate with resonant energy.

--- a/_datafiles/world/default/rooms/bladeworks_foundry/zone-config.yaml
+++ b/_datafiles/world/default/rooms/bladeworks_foundry/zone-config.yaml
@@ -1,0 +1,16 @@
+name: Bladeworks Foundry
+roomid: 3001
+autoscale:
+  minimum: 6
+  maximum: 15
+idlemessages:
+  - The rhythmic clang of distant machinery echoes through the halls.
+  - Steam hisses from a crack in the pipes somewhere nearby.
+  - A gear grinds against metal, sending sparks into the dim light.
+  - Sword-shaped chandeliers sway gently, their glass blades catching the forge light.
+  - The acrid smell of hot metal and oil hangs heavy in the air.
+  - A construct's footsteps clank somewhere in the distance.
+  - Spinning saw blades whir ominously from behind a wall.
+  - The furnaces roar with eternal flame, hungry for more steel.
+musicfile: static/audio/music/bladeworks-foundry.mp3
+defaultbiome: dungeon

--- a/_datafiles/world/default/rooms/whispering_wastes/168.yaml
+++ b/_datafiles/world/default/rooms/whispering_wastes/168.yaml
@@ -17,5 +17,13 @@ exits:
     roomid: 167
   northwest:
     roomid: 169
+  south:
+    roomid: 3001
+nouns:
+  foundry: Through the swirling snow to the south, you can barely make out the massive
+    iron doors of an abandoned building. Strange heat emanates from within, and the
+    faint sound of grinding machinery can be heard.
+  building: The building to the south is clearly industrial in nature - iron walls,
+    smoke stacks, and massive doors. This must be the legendary Bladeworks Foundry.
 idlemessages:
 - The wind howls from every direction.


### PR DESCRIPTION
## Summary
Bert's first zone! A 20-room steampunk blade factory where **EVERYTHING IS SWORDS**.

## Features
- **Level range**: 6-15 (two-tier split)
- **The Assembly Line** (L6-10): Fast aggro constructs, industrial chaos
- **Hall of Endless Blades** (L11-15): Steam Golems, deadly hardmode
- **Dual-wield trainer**: Room 3012, teaches levels 1-4
- **Blade Merchant**: Sells the legendary Three-Bladed Sword (**ONLY 3 EXIST!**)
- **Boss**: Voltaic Promethean (L15 electric construct)

## New Content
- 20 rooms
- 7 mobs (5 constructs + 2 NPCs)
- 6 weapons (including Three-Bladed Sword - 1d6, -2 speed, 300g)
- 1 armor (Promethean Chassis boss drop)

## Connection
South of Whispering Wastes room 168

## Test Plan
- [ ] Navigate to Whispering Wastes room 168, go south
- [ ] Explore Assembly Line (L6-10 area)
- [ ] Find dual-wield trainer
- [ ] Enter Hall of Endless Blades (L11-15)
- [ ] Find Blade Merchant, buy Three-Bladed Sword
- [ ] Fight Voltaic Promethean

THERE CAN BE ONLY THREE! 🗡️🗡️🗡️

🤖 Generated with [Claude Code](https://claude.com/claude-code)