### PR TITLE
Fix promethean chassis item type and add Galstaff NPC

### DIFF
--- a/_datafiles/world/default/items/armor-20000/body/20048-promethean_chassis.yaml
+++ b/_datafiles/world/default/items/armor-20000/body/20048-promethean_chassis.yaml
@@ -7,8 +7,9 @@ description: This suit of armor was forged from salvaged plates of the Voltaic
   crackles across its surface, and the armor seems to repair minor damage
   on its own over time. Wearing it fills you with a strange confidence,
   as if the Promethean's indomitable will has become your own.
-type: armor
-subtype: body
+type: body
+subtype: wearable
+damagereduction: 15
 value: 3500
 statmods:
   strength: 2

--- a/_datafiles/world/default/mobs/frostfang/90-galstaff.yaml
+++ b/_datafiles/world/default/mobs/frostfang/90-galstaff.yaml
@@ -1,0 +1,34 @@
+mobid: 90
+zone: Frostfang
+itemdropchance: 0
+hostile: false
+maxwander: 10
+homeroomid: 61
+groups:
+  - frostfang-npc
+  - quest-giver
+idlecommands:
+  - 'say Have you heard? Crystal caves have been discovered beyond the West Gate! Flora found them while gathering herbs.'
+  - emote strokes his long beard thoughtfully.
+  - 'say The Bladeworks Foundry has reopened! Bert claims he saw constructs still working the forges.'
+  - 'say Adventurers seeking glory should explore the new zones. Crystal Caves for the young, the Foundry for the seasoned.'
+  - emote pulls out a worn map and studies it intently.
+  - 'say I have catalogued many dungeons in my time. These new discoveries are most exciting!'
+  - emote adjusts his pointed hat.
+  - 'say The Bladeworks Foundry... they say there are only THREE of some legendary blade there. Most curious.'
+  - 'say Crystal formations of unusual magical potency have been reported in the caves. Spelunkers beware!'
+  - emote mutters something about "initiative order" under his breath.
+activitylevel: 30
+character:
+  name: Galstaff, Sorcerer of Light
+  description: This elderly wizard wears flowing robes of deep blue adorned with silver
+    stars and moons. His long white beard reaches nearly to his waist, and his
+    pointed hat sits slightly askew atop his head. He carries a gnarled oak staff
+    topped with a softly glowing crystal, and a worn leather satchel bulges with
+    scrolls and maps. His eyes twinkle with barely contained enthusiasm as he
+    speaks of dungeons, monsters, and legendary treasures. He seems to know an
+    awful lot about the layout of the world, almost as if he designed it himself.
+  raceid: 1
+  level: 20
+  alignment: 100
+  gold: 50

--- a/_datafiles/world/default/rooms/frostfang/61.yaml
+++ b/_datafiles/world/default/rooms/frostfang/61.yaml
@@ -22,3 +22,6 @@ spawninfo:
   message: A serving wench enters from a back room.
   levelmod: 10
   respawnrate: 2 real minutes
+- mobid: 90
+  message: Galstaff shuffles in, muttering about dungeon layouts.
+  respawnrate: 5 real minutes


### PR DESCRIPTION
## Summary
- Fixes PANIC error: promethean chassis had `type: armor` instead of `type: body` (items in body/ directory must have type: body)
- Adds Galstaff, Sorcerer of Light NPC (mob 90) who wanders between Frostfire Inn and Snarky Squirrel announcing new zones
- Galstaff mentions Crystal Caves, Bladeworks Foundry, and the legendary Three-Bladed Sword

## Test plan
- [ ] Server starts without PANIC
- [ ] Visit Frostfire Inn (room 61) to see Galstaff spawn
- [ ] Wait for Galstaff to wander and announce zones
- [ ] Verify promethean chassis can be equipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)