### PR TITLE
Fix map display at West Gate

### DIFF
--- a/_datafiles/world/default/rooms/frostfang/167.yaml
+++ b/_datafiles/world/default/rooms/frostfang/167.yaml
@@ -11,7 +11,9 @@ description: Outside of the frost-covered gates to the west of Frostfang, the bi
   from the blizzard, like ghostly sentinels watching over this desolate expanse. To
   the south, a frost-covered hillside features a dark opening from which a faint blue
   glow and warm air emanate.
-biome: city
+mapsymbol: "○"
+maplegend: Outside
+biome: outdoors
 exits:
   east:
     roomid: 35


### PR DESCRIPTION
## Summary
- Room 167 (Outside West Gate) was missing `mapsymbol` and `maplegend`
- Added ○ symbol and "Outside" legend
- Changed biome from "city" to "outdoors"

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)