### PR TITLE
Crystal Caves: down/up entrance instead of south/north

### DIFF
--- a/_datafiles/world/default/rooms/crystal_caves/2001.yaml
+++ b/_datafiles/world/default/rooms/crystal_caves/2001.yaml
@@ -11,7 +11,7 @@ mapsymbol: E
 maplegend: Entrance
 biome: dungeon
 exits:
-  north:
+  up:
     roomid: 167
   south:
     roomid: 2002

--- a/_datafiles/world/default/rooms/frostfang/167.yaml
+++ b/_datafiles/world/default/rooms/frostfang/167.yaml
@@ -8,27 +8,25 @@ description: Outside of the frost-covered gates to the west of Frostfang, the bi
   under the thick blanket of white. The howling wind carries faint, eerie whispers,
   hinting at the mysteries and dangers hidden within this relentless winter storm.
   To your left and right, the silhouettes of frozen structures emerge sporadically
-  from the blizzard, like ghostly sentinels watching over this desolate expanse. To
-  the south, a frost-covered hillside features a dark opening from which a faint blue
-  glow and warm air emanate.
+  from the blizzard, like ghostly sentinels watching over this desolate expanse. At
+  your feet, a dark opening in the frost-covered ground reveals a passage descending
+  into the earth, from which a faint blue glow and warm air emanate.
 mapsymbol: "○"
 maplegend: Outside
 biome: outdoors
 exits:
   east:
     roomid: 35
-  south:
+  down:
     roomid: 2001
   west:
     roomid: 168
 nouns:
-  hillside: Looking south, you notice a frost-covered hillside with a dark opening
-    partially hidden by snow and ice. A faint blue glow emanates from within, and
-    warm air rises from the entrance, melting the snow around it.
-  opening: The opening in the hillside is just large enough to enter. Strange blue
+  opening: The opening in the ground is just large enough to descend into. Strange blue
     light pulses from within. Local legends speak of crystal caves beneath the frozen ground.
-  cave: The cave entrance beckons with its strange blue glow. Warm air drifts out,
+  cave: The cave entrance beckons with its strange blue glow. Warm air drifts up,
     a stark contrast to the frozen landscape.
+  hole: A dark passage descends into the earth. You can feel warm air rising from below.
 idlemessages:
 - The icy wind envelopes you.
 - The gate creaks in the wind.


### PR DESCRIPTION
## Summary
- Cave entrance is now DOWN from Outside West Gate
- Exit is UP back to surface
- Updated room descriptions to match

Fixes map layout issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)