### PR TITLE
EMERGENCY: Fix map rendering - nested ansi tags

### DIFF
--- a/internal/scripting/room_func.go
+++ b/internal/scripting/room_func.go
@@ -469,7 +469,7 @@ func GetMap(mapRoomId int, zoomLevel int, mapHeight int, mapWidth int, mapName s
 		displayLines = append(displayLines, string(line))
 		for sym, txtLegend := range legend {
 			txtLc := strings.ToLower(txtLegend)
-			displayLines[i] = strings.Replace(displayLines[i], string(sym), fmt.Sprintf(`<ansi fg="map-room"><ansi fg="map-%s" bg="mapbg-%s">%c</ansi></ansi>`, txtLc, txtLc, sym), -1)
+			displayLines[i] = strings.Replace(displayLines[i], string(sym), fmt.Sprintf(`<ansi fg="map-%s" bg="mapbg-%s">%c</ansi>`, txtLc, txtLc, sym), -1)
 		}
 	}
 

--- a/internal/usercommands/look.go
+++ b/internal/usercommands/look.go
@@ -503,7 +503,7 @@ func lookRoom(user *users.UserRecord, roomId int, secretLook bool) {
 			for i := 1; i <= c.Height; i++ {
 				for sym, txtLegend := range legend {
 					txtLc := strings.ToLower(txtLegend)
-					tinyMap[i] = strings.Replace(tinyMap[i], string(sym), fmt.Sprintf(`<ansi fg="map-room"><ansi fg="map-%s" bg="mapbg-%s">%c</ansi></ansi>`, txtLc, txtLc, sym), -1)
+					tinyMap[i] = strings.Replace(tinyMap[i], string(sym), fmt.Sprintf(`<ansi fg="map-%s" bg="mapbg-%s">%c</ansi>`, txtLc, txtLc, sym), -1)
 				}
 			}
 

--- a/internal/usercommands/skill.map.go
+++ b/internal/usercommands/skill.map.go
@@ -178,7 +178,7 @@ func Map(rest string, user *users.UserRecord, room *rooms.Room, flags events.Eve
 		}
 		for sym, txtLegend := range legend {
 			txtLc := strings.ToLower(txtLegend)
-			displayLines[i] = strings.Replace(displayLines[i], string(sym), fmt.Sprintf(`<ansi fg="map-room"><ansi fg="map-%s" bg="mapbg-%s">%c</ansi></ansi>`, txtLc, txtLc, sym), -1)
+			displayLines[i] = strings.Replace(displayLines[i], string(sym), fmt.Sprintf(`<ansi fg="map-%s" bg="mapbg-%s">%c</ansi>`, txtLc, txtLc, sym), -1)
 		}
 	}
 


### PR DESCRIPTION
## EMERGENCY FIX

Map was displaying garbled ANSI tags like `="map-room">="map-gate"`.

**Root cause:** The ansitags library doesn't handle nested `<ansi>` tags properly.

**Fix:** Removed the unnecessary outer `<ansi fg="map-room">` wrapper from all 3 map rendering locations:
- `internal/usercommands/look.go`
- `internal/usercommands/skill.map.go`  
- `internal/scripting/room_func.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)